### PR TITLE
Allow party names to contain square brackets

### DIFF
--- a/scraper/parser.py
+++ b/scraper/parser.py
@@ -50,7 +50,7 @@ class PartyParser(dict):
             return (None, name)
 
         match = re.match(
-            r'([^\[]+)\[De-registered ([0-9]+/[0-9]+/[0-9]+)\]', name)
+            r'(.+)\[De-registered ([0-9]+/[0-9]+/[0-9]+)\]', name)
         name, date = match.groups()
         name = re.sub(r'\([Dd]e-?registered [^\)]+\)', '', name)
         return name.strip(), self._text_to_iso_date(date)


### PR DESCRIPTION
“Free Scotland Party [FSP]” was breaking the parser. This change makes
the regex less strict, so names containing square brackets still parse.
